### PR TITLE
add headless-gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@
 ### Trigonometry functions
 
 [![Circle trigonometry](data/circle_cos_sin.gif)](https://en.wikipedia.org/wiki/Trigonometric_functions)
+
+### Software
+
+**WebGL**
+
+* [headless-gl](https://github.com/stackgl/headless-gl) - windowless WebGL for node.js. Ideal for making artsy bots!


### PR DESCRIPTION
I also added a `Software` category under `graphics` but on second thoughts maybe it could be its own category and we just leave *Graphics* and *Audio* as a somewhat visual catalogue of techniques, and have a *Software* category with lists of cool usable stuff, what do you think? @belen-albeza @lrlna 